### PR TITLE
Use AWS session token when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@
 ## Environment Variables
 #### AWS_ACCESS_KEY_ID
 - Required: ***True***
-- Description: Access Key ID of the user being rotated. You can use `${{secrets.ACCESS_KEY_ID}}`
+- Description: Access Key ID to authenticate with AWS. You can use `${{secrets.ACCESS_KEY_ID}}`
 
 #### AWS_SECRET_ACCESS_KEY
 - Required: ***True***
-- Description: Secret Access Key ID of the user being rotated. You can use `${{secrets.SECRET_ACCESS_KEY_ID}}`
+- Description: Secret Access Key ID to authenticate with AWS. You can use `${{secrets.SECRET_ACCESS_KEY_ID}}`
+
+#### AWS_SESSION_TOKEN
+- Required: ***False***
+- Description: Session Token for the current AWS session. Only required if you assume a role first.
 
 #### IAM_USERNAME
 - Required: ***True***

--- a/rotate_keys.py
+++ b/rotate_keys.py
@@ -17,7 +17,8 @@ if 'GITHUB_SECRET_KEY_NAME' in os.environ:
 iam = boto3.client(
     'iam',
     aws_access_key_id = os.environ['AWS_ACCESS_KEY_ID'],
-    aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY']
+    aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY'],
+    aws_session_token = os.environ['AWS_SESSION_TOKEN'] if 'AWS_SESSION_TOKEN' in os.environ else None
 )
 
 def main_function():


### PR DESCRIPTION
Hi 👋 

In some cases users of this action may which to assume a dedicated role and then update the keys of a user from there.

When you [configure AWS credentials](https://github.com/aws-actions/configure-aws-credentials#assuming-a-role) you can assume a role. This will put the session token in your env variables.

To allow for this, this action has to provide the session token to the boto client, so this PR does that if the env var exists.

I've also updated the readme.