### PR TITLE
Only delete the old key after secret successfully updated on github

### DIFF
--- a/rotate_keys.py
+++ b/rotate_keys.py
@@ -9,7 +9,7 @@ secret_key_name = "secret_key_id"
 # checks if values set to override default
 if 'GITHUB_ACCESS_KEY_NAME' in os.environ:
     access_key_name = os.environ['GITHUB_ACCESS_KEY_NAME']
-    
+
 if 'GITHUB_SECRET_KEY_NAME' in os.environ:
     secret_key_name = os.environ['GITHUB_SECRET_KEY_NAME']
 
@@ -25,7 +25,7 @@ def main_function():
     iam_username = os.environ['IAM_USERNAME']
     github_token = os.environ['GITHUB_TOKEN']
     owner_repository = os.environ['OWNER_REPOSITORY']
-    
+
     list_ret = iam.list_access_keys(UserName=iam_username)
     starting_num_keys = len(list_ret["AccessKeyMetadata"])
 
@@ -42,9 +42,6 @@ def main_function():
     #generate new credentials
     (new_access_key, new_secret_key) = create_new_keys(iam_username)
 
-    #delete old keys
-    delete_old_keys(iam_username, current_access_id)
-
     #get repo pub key info
     (public_key, pub_key_id) = get_pub_key(owner_repository, github_token)
 
@@ -55,6 +52,9 @@ def main_function():
     #upload secrets
     upload_secret(owner_repository,access_key_name,encrypted_access_key,pub_key_id,github_token)
     upload_secret(owner_repository,secret_key_name,encrypted_secret_key,pub_key_id,github_token)
+
+    #delete old keys
+    delete_old_keys(iam_username, current_access_id)
 
     sys.exit(0)
 
@@ -87,7 +87,7 @@ def delete_old_keys(iam_username,current_access_id):
     if delete_ret['ResponseMetadata']['HTTPStatusCode'] != 200:
         print("deletion of original key failed")
         sys.exit(1)
-        
+
 ## Update Actions Secret
 # https://developer.github.com/v3/actions/secrets/#create-or-update-a-secret-for-a-repository
 def encrypt(public_key: str, secret_value: str) -> str:
@@ -117,7 +117,7 @@ def get_pub_key(owner_repo, github_token):
 
     return (public_key, public_key_id)
 
-def upload_secret(owner_repo,key_name,encrypted_value,pub_key_id,github_token):    
+def upload_secret(owner_repo,key_name,encrypted_value,pub_key_id,github_token):
     #upload encrypted access key
     updated_secret = requests.put(
         f'https://api.github.com/repos/{owner_repo}/actions/secrets/{key_name}',


### PR DESCRIPTION
This covers the corner case where for some reason (e.g. invalid github key), updating secret fails.
With the current code, the old key will already be deleted and other workflows that use the secret will stop working.
With the proposed code, both the new and the old keys will still exist and other workflows will continue working. If the failure is not handled, the next rotation will also fail because it will have >1 keys.