### PR TITLE
Multi repos support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 #### OWNER_REPOSITORY
 - Required: ***True***
-- Description: The owner and repository name. For example, octocat/Hello-World. If being ran in the repo being updated, you can use `${{github.repository}}`
+- Description: The owner and repository name. For example, octocat/Hello-World. If being ran in the repo being updated, you can use `${{github.repository}}`. Multiple repositories can be specified by a comma-separated list.
 
 #### GITHUB_ACCESS_KEY_NAME
 - Required: ***False***

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 #### OWNER_REPOSITORY
 - Required: ***True***
-- Description: The owner and repository name. For example, octocat/Hello-World. If being ran in the repo being updated, you can use `${{github.repository}}`. Multiple repositories can be specified by a comma-separated list.
+- Description: The owner and repository name. For example, octocat/Hello-World. If being ran in the repo being updated, you can use `${{github.repository}}`. Multiple repositories can be specified by a comma-separated list (e.g. `OWNER_REPOSITORY: ${{ github.repository }},MyGitHubOrgOrUser/MyGitHubRepo`). 
 
 #### GITHUB_ACCESS_KEY_NAME
 - Required: ***False***

--- a/rotate_keys.py
+++ b/rotate_keys.py
@@ -25,7 +25,7 @@ def main_function():
     iam_username = os.environ['IAM_USERNAME']
     github_token = os.environ['GITHUB_TOKEN']
     owner_repository = os.environ['OWNER_REPOSITORY']
-    
+
     list_ret = iam.list_access_keys(UserName=iam_username)
     starting_num_keys = len(list_ret["AccessKeyMetadata"])
 
@@ -45,16 +45,17 @@ def main_function():
     #delete old keys
     delete_old_keys(iam_username, current_access_id)
 
-    #get repo pub key info
-    (public_key, pub_key_id) = get_pub_key(owner_repository, github_token)
+    for repos in [x.strip() for x in owner_repository.split(',')]:
+        #get repo pub key info
+        (public_key, pub_key_id) = get_pub_key(repos, github_token)
 
-    #encrypt the secrets
-    encrypted_access_key = encrypt(public_key,new_access_key)
-    encrypted_secret_key = encrypt(public_key,new_secret_key)
+        #encrypt the secrets
+        encrypted_access_key = encrypt(public_key,new_access_key)
+        encrypted_secret_key = encrypt(public_key,new_secret_key)
 
-    #upload secrets
-    upload_secret(owner_repository,access_key_name,encrypted_access_key,pub_key_id,github_token)
-    upload_secret(owner_repository,secret_key_name,encrypted_secret_key,pub_key_id,github_token)
+        #upload secrets
+        upload_secret(repos,access_key_name,encrypted_access_key,pub_key_id,github_token)
+        upload_secret(repos,secret_key_name,encrypted_secret_key,pub_key_id,github_token)
 
     sys.exit(0)
 

--- a/rotate_keys.py
+++ b/rotate_keys.py
@@ -132,9 +132,9 @@ def upload_secret(owner_repo,key_name,encrypted_value,pub_key_id,github_token):
     good_status_codes = [204,201]
 
     if updated_secret.status_code not in good_status_codes:
-        print(f'Got status code: {updated_secret.status_code} on updating {key_name}')
+        print(f'Got status code: {updated_secret.status_code} on updating {key_name} in {owner_repo}')
         sys.exit(1)
-    print(f'Uploaded {key_name} to {owner_repo}.')
+    print(f'Updated {key_name} in {owner_repo}')
 
 # run everything
 main_function()

--- a/rotate_keys.py
+++ b/rotate_keys.py
@@ -134,6 +134,7 @@ def upload_secret(owner_repo,key_name,encrypted_value,pub_key_id,github_token):
     if updated_secret.status_code not in good_status_codes:
         print(f'Got status code: {updated_secret.status_code} on updating {key_name}')
         sys.exit(1)
+    print(f'Uploaded {key_name} to {owner_repo}.')
 
 # run everything
 main_function()


### PR DESCRIPTION
Hello.

Some might want to update GitHub Secrets in multiple repositories by specifying two or more repos in `OWNER_REPOSITORY`.  eg. `OWNER_REPOSITORY: ${{ github.repository }},ScatteredTuna/supreme-tuna`.

@kneemaa  Could you take a look at the PR if you have time?

Thanks.