### PR TITLE
Rename GITHUB_TOKEN env var to PERSONAL_ACCESS_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 - Required: ***True***
 - Description: Name of IAM user being rotated
 
-#### GITHUB_TOKEN
+#### PERSONAL_ACCESS_TOKEN
 - Required: ***True***
-- Description: Github Token with **Repo Admin** access of the target repo. As of 4/16/2020 `${{github.token}}` does not have permission to query the Secrets API.
+- Description: Github Token with **Repo Admin** access of the target repo. As of 4/16/2020 `${{github.token}}` does not have permission to query the Secrets API. The existing env var GITHUB_TOKEN which is added automatically to all runs does not have the access secrets.
 
 #### OWNER_REPOSITORY
 - Required: ***True***
@@ -55,7 +55,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.access_key_name }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key_name }}
           IAM_USERNAME: 'iam-user-name'
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           OWNER_REPOSITORY: ${{ github.repository }}
 ```
 
@@ -78,7 +78,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.access_key_name }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key_name }}
           IAM_USERNAME: 'iam-user-name'
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           OWNER_REPOSITORY: ${{ github.repository }}
 
       - name: Send Slack Status

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 - Description: Session Token for the current AWS session. Only required if you assume a role first.
 
 #### IAM_USERNAME
-- Required: ***True***
-- Description: Name of IAM user being rotated
+- Required: ***False***
+- Description: Name of IAM user being rotated, if not set the username which is used in the AWS credentials is used
 
 #### PERSONAL_ACCESS_TOKEN
 - Required: ***True***

--- a/rotate_keys.py
+++ b/rotate_keys.py
@@ -23,7 +23,7 @@ iam = boto3.client(
 
 def main_function():
     iam_username = os.environ['IAM_USERNAME']
-    github_token = os.environ['GITHUB_TOKEN']
+    github_token = os.environ['PERSONAL_ACCESS_TOKEN']
     owner_repository = os.environ['OWNER_REPOSITORY']
 
     list_ret = iam.list_access_keys(UserName=iam_username)

--- a/rotate_keys.py
+++ b/rotate_keys.py
@@ -22,7 +22,7 @@ iam = boto3.client(
 )
 
 def main_function():
-    iam_username = os.environ['IAM_USERNAME']
+    iam_username = os.environ['IAM_USERNAME'] if 'IAM_USERNAME' in os.environ else who_am_i()
     github_token = os.environ['PERSONAL_ACCESS_TOKEN']
     owner_repository = os.environ['OWNER_REPOSITORY']
 
@@ -58,6 +58,19 @@ def main_function():
     delete_old_keys(iam_username, current_access_id)
 
     sys.exit(0)
+
+def who_am_i():
+    # ask the aws backend for myself with a boto3 sts client
+    sts = boto3.client(
+        'sts',
+        aws_access_key_id = os.environ['AWS_ACCESS_KEY_ID'],
+        aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY'],
+        aws_session_token = os.environ['AWS_SESSION_TOKEN'] if 'AWS_SESSION_TOKEN' in os.environ else None
+    )
+
+    user = sts.get_caller_identity()
+    # return last element of splitted list to get username
+    return user['Arn'].split("/")[-1]
 
 def create_new_keys(iam_username):
     # create the keys


### PR DESCRIPTION
use PERSONAL_ACCESS_TOKEN to ensure the GITHUB_TOKEN env var default value is not used.