### PR TITLE
fix cron examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@
 - Description: Name of the [Github environment](https://docs.github.com/en/actions/reference/environments) where the secrets are stored. 
 
 # Example
-## Rotation every monday at 13:00 UTC
+## Rotation every monday at 13:27 UTC
 ```
 on:
   schedule:
-    - cron: '* 13 * * 1' 
+    - cron: '27 13 * * 1' 
 
 jobs:
   rotate:
@@ -63,12 +63,12 @@ jobs:
           OWNER_REPOSITORY: ${{ github.repository }}
 ```
 
-## Rotation every monday at 13:00 UTC for the `dev` Github environment secret
+## Rotation every monday at 13:27 UTC for the `dev` Github environment secret
 
 ```
 on:
   schedule:
-    - cron: '* 13 * * 1' 
+    - cron: '27 13 * * 1' 
 
 jobs:
   rotate:
@@ -99,7 +99,7 @@ Note that environment names must be set twice:
 ```
 on:
   schedule:
-    - cron: '* 13 * * 1'
+    - cron: '27 13 * * 1'
 
 jobs:
   rotate:


### PR DESCRIPTION
`* 13 * * 1` runs every minute in the 13:00 UTC hour on Mondays. Oops, it should only run once per week.

Using '27' as an arbitrary time to keep from every cron running in the zeroth minute. Keeping that number consistent in the examples just out of simplicity.